### PR TITLE
fix: ignore correct file extension

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ def list_all_files(source_folder):
     for (_, _, filenames) in os.walk(source_folder):
         temp = []
         for filename in filenames:
-            if not filename.endswith('_raw.png.png'):
+            if not filename.endswith('_raw.png'):
                 temp.append(filename)
         return temp
 


### PR DESCRIPTION
This PR addresses a bug where the code was not correctly ignoring files with the extension "_raw.png".

Related to PR: [https://github.com/chatgpt4pcg/modified-science-birds/pull/1](https://github.com/chatgpt4pcg/modified-science-birds/pull/1)